### PR TITLE
Remove OAuth Filter config & Update CI/CD reference action locations

### DIFF
--- a/.github/actions/docker-compose/action.yml
+++ b/.github/actions/docker-compose/action.yml
@@ -1,0 +1,46 @@
+# Copyright Jiaqi Liu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Start JPA-Elide webservice in Docker Compose'
+description: 'Packaging JPA-Elide webservice and start a Docker Compose with its resulting WAR'
+
+inputs:
+  webservice-repo-clone-url:
+    description: 'The git clone URL used to checkout the JPA-Elide webservice, e.g. "https://github.com/QubitPi/jersey-webservice-template.git"'
+    required: true
+  repo-branch:
+    description: 'The repo branch that contains the docker-compose.yml file. Default to "master" branch'
+    required: false
+    default: "master"
+  model-package:
+    description: 'The Java package name containing all JPA-Elide webservice data models, e.g. "com.myorg.webservice.astraios.models"'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - run: git clone -b ${{ inputs.repo-branch }} ${{ inputs.webservice-repo-clone-url }} jpa-elide-webservice
+      shell: bash
+    - name: Generate webservice WAR file
+      run: |
+        cd jpa-elide-webservice
+        mvn -B clean package
+        cd ../
+      shell: bash
+    - name: Start Docker Compose
+      run: |
+        cd jpa-elide-webservice
+        MODEL_PACKAGE_NAME=${{ inputs.model-package }} docker compose up --build --force-recreate &
+        cd ../
+      shell: bash

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -52,7 +52,6 @@ jobs:
           webservice-repo-clone-url: https://github.com/QubitPi/jersey-webservice-template.git
           repo-branch: jpa-elide
           model-package: com.qubitpi.ws.jersey.template.models
-          oauth-enabled: false
       - name: Wait until Docker Compose is up
         uses: iFaxity/wait-on-action@v1
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,18 +36,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup JDK
-        uses: QubitPi/hashicorp-aws/.github/actions/jdk-setup@master
+        uses: QubitPi/jersey-webservice-deployment-actions/.github/actions/jdk-setup@master
       - name: Download data models
         run: git clone https://github.com/QubitPi/jersey-webservice-template-jpa-data-models.git ../data-models
       - name: Install data-models
-        uses: QubitPi/hashicorp-aws/.github/actions/jersey-webservice-template/jpa-elide/install-data-models@master
+        uses: QubitPi/jersey-webservice-deployment-actions/.github/actions/jpa-elide/install-data-models@master
         with:
           model-package-jar-group-id: com.qubitpi
           model-package-jar-artifact-id: jersey-webservice-template-jpa-data-models
           model-package-jar-version: 1.0.0
           models-path: ../data-models
       - name: Spin up Jersey Webservice Template (jpa-elide branch) instance in Docker Compose
-        uses: QubitPi/hashicorp-aws/.github/actions/jersey-webservice-template/jpa-elide/docker-compose@master
+        uses: ./.github/actions/docker-compose
         with:
           webservice-repo-clone-url: https://github.com/QubitPi/jersey-webservice-template.git
           repo-branch: jpa-elide

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ License
 -------
 
 The use and distribution terms for [jersey-webservice-template-jpa-data-models-acceptance-tests] are covered by the
-[Apache License, Version 2.0][Apache License, Version 2.0].
+[Apache License, Version 2.0].
 
 <div align="center">
     <a href="https://opensource.org/licenses">


### PR DESCRIPTION
- Remove OAuth Filter config due to https://github.com/QubitPi/jersey-webservice-template/pull/145
- Update CI/CD referenced action location due to https://github.com/QubitPi/hashicorp-aws/pull/143 and https://github.com/QubitPi/jersey-webservice-deployment-actions/commit/9d6b3e9fee31be624ae911e2f430d73b9636129b